### PR TITLE
Update DisenchantListener.java

### DIFF
--- a/src/main/java/io/KiritoKing/DisenchantListener.java
+++ b/src/main/java/io/KiritoKing/DisenchantListener.java
@@ -70,6 +70,7 @@ public class DisenchantListener implements Listener {
     Inventory inv = e.getClickedInventory();
     if (inv == null) return;
     if (inv.getType() != InventoryType.ANVIL) return;
+    if (inv.getItem(0) == null) return;
     if (inv.getItem(0).getType() == Material.ENCHANTED_BOOK) return; // 当源物品是附魔书时不响应
     if (inv.getItem(2) == null) return; // 当没有出现结果时不响应
 


### PR DESCRIPTION
See below error from server logs. Simple fix to handle case where getType() is attempting to be invoked on null (items are removed from anvil when clicking). Otherwise, plugin works great!

[17:43:53 ERROR]: Could not pass event InventoryClickEvent to DisenchantableAnvil v2.0.1 java.lang.NullPointerException: Cannot invoke "org.bukkit.inventory.ItemStack.getType()" because the return value of "org.bukkit.inventory.Inventory.getItem(int)" is null
        at io.KiritoKing.DisenchantListener.onClickInventory(DisenchantListener.java:73) ~[DisenchantableAnvil.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor168.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.19.4-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:81) ~[paper-api-1.19.4-R0.1-SNAPSHOT.jar:git-Paper-511]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.4-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.19.4.jar:git-Paper-511]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[paper-1.19.4.jar:git-Paper-511]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:615) ~[paper-api-1.19.4-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3189) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:58) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:23) ~[?:?]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:51) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1342) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:197) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1319) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1312) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1290) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1178) ~[paper-1.19.4.jar:git-Paper-511]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:320) ~[paper-1.19.4.jar:git-Paper-511]
        at java.lang.Thread.run(Thread.java:1623) ~[?:?]